### PR TITLE
Shortens runner role name to allow longer repo names

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.1
+current_version = 3.2.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/_internal/runner/main.tf
+++ b/modules/_internal/runner/main.tf
@@ -91,7 +91,8 @@ data "aws_iam_policy_document" "codebuild" {
 }
 
 resource "aws_iam_role" "codebuild" {
-  name               = "${local.name_slug}-codebuild-service-role"
+  name_prefix        = "flow-ci-codebuild-service-role-"
+  description        = "${local.name_slug}-codebuild-service-role -- Managed by Terraform"
   assume_role_policy = "${data.aws_iam_policy_document.codebuild_assume_role.json}"
 }
 


### PR DESCRIPTION
Previously, the runner IAM role name was based on a combination of user input (the repo name) and a handful of internally-configured tokens. Unfortunately, the IAM role name is limited to 64 characters. The prior method would fail if the user passed in a repo name of a certain length (I didn't count out the exact point of failure).

The new method uses the name_prefix option to ensure the name is unique, and places the prior name into the description field so the information is still available.