### PR TITLE
Changes count to reference same var as linked resource

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.0
+current_version = 4.1.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tardigrade-ci/
 
 # eclint
 .git/
+
+# terratest packaging
+tests/go.*

--- a/modules/_internal/runner/main.tf
+++ b/modules/_internal/runner/main.tf
@@ -113,7 +113,7 @@ data "aws_iam_policy" "codebuild" {
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild" {
-  count = length(data.aws_iam_policy.codebuild.*.arn)
+  count = length(var.policy_arns)
 
   role       = aws_iam_role.codebuild.id
   policy_arn = element(data.aws_iam_policy.codebuild.*.arn, count.index)

--- a/tests/module_test.go
+++ b/tests/module_test.go
@@ -1,0 +1,66 @@
+package testing
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestModule(t *testing.T) {
+	files, err := ioutil.ReadDir("./")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range files {
+		// look for directories with test cases in it
+		if f.IsDir() && f.Name() != "vendor" {
+			tfFiles, tfErr := ioutil.ReadDir(f.Name())
+
+			if tfErr != nil {
+				log.Fatal(tfErr)
+			}
+
+			// check if directory contains terraform files
+			terraformDir := false
+			for _, tf := range tfFiles {
+				if strings.HasSuffix(tf.Name(), ".tf") {
+					terraformDir = true
+					break
+				}
+			}
+
+			// create a test for each directory with terraform files in it
+			if terraformDir {
+				t.Run(f.Name(), func(t *testing.T) {
+					// check if a prereq directory exists
+					prereqDir := f.Name() + "/prereq/"
+					if _, err := os.Stat(prereqDir); err == nil {
+						prereqOptions := createTerraformOptions(prereqDir)
+						defer terraform.Destroy(t, prereqOptions)
+						terraform.InitAndApply(t, prereqOptions)
+					}
+
+					// run terraform code for test case
+					terraformOptions := createTerraformOptions(f.Name())
+					defer terraform.Destroy(t, terraformOptions)
+					terraform.InitAndApply(t, terraformOptions)
+				})
+			}
+		}
+	}
+}
+
+func createTerraformOptions(directory string) *terraform.Options {
+	terraformOptions := &terraform.Options{
+		TerraformDir: directory,
+		NoColor:      true,
+	}
+
+	return terraformOptions
+}

--- a/tests/module_test.go
+++ b/tests/module_test.go
@@ -50,6 +50,9 @@ func TestModule(t *testing.T) {
 					terraformOptions := createTerraformOptions(f.Name())
 					defer terraform.Destroy(t, terraformOptions)
 					terraform.InitAndApply(t, terraformOptions)
+
+					// run terraform apply a second time to detect issues with follow-on plan
+					terraform.Apply(t, terraformOptions)
 				})
 			}
 		}


### PR DESCRIPTION
Fixes errors like this:

```
Error: Invalid count argument

  on ../../modules/_internal/runner/main.tf line 116, in resource "aws_iam_role_policy_attachment" "codebuild":
 116:   count = length(data.aws_iam_policy.codebuild.*.arn)

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```