### PR TITLE
Uses "arn" to get the arn, not id

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.4
+current_version = 4.3.5
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/_internal/runner/outputs.tf
+++ b/modules/_internal/runner/outputs.tf
@@ -1,6 +1,6 @@
 output "codebuild_project_arn" {
   description = "ARN of the CodeBuild Project"
-  value       = aws_codebuild_project.this.id
+  value       = aws_codebuild_project.this.arn
 }
 
 output "codebuild_project_name" {


### PR DESCRIPTION
When a codebuild project is imported, the id is the value used for
the import, which may be either the name or the arn. For this output,
we always want the arn.